### PR TITLE
bug fix of pom.xml on thrift

### DIFF
--- a/llama/pom.xml
+++ b/llama/pom.xml
@@ -231,7 +231,7 @@
                 <exec executable="thrift" failonerror="true">
                   <arg value="--gen"/>
                   <arg value="java"/>
-                  <arg value="-out"/>
+                  <arg value="--out"/>
                   <arg
                     value="${project.build.directory}/generated-sources/java"/>
                   <arg value="${basedir}/src/main/thrift/Llama.thrift"/>


### PR DESCRIPTION
This is a bug on the thrift part. The wrong argument won't generate thrift java code. 
