### PR TITLE
Patch to fix DONT_CARE locality enforcement flag that is ignored at the moment

### DIFF
--- a/llama-dist/src/main/conf/llama-site.xml
+++ b/llama-dist/src/main/conf/llama-site.xml
@@ -473,6 +473,14 @@
     </description>
   </property>
   <property>
+    <name>llama.am.resource.normalizing.enabled.#QUEUE#</name>
+    <value>true</value>
+    <description>
+      Per queue setting that indicates whether to break resource requests into smaller requests of standard size
+      before the cache.
+    </description>
+  </property>
+  <property>
     <name>llama.am.resource.normalizing.standard.mbs</name>
     <value>1024</value>
     <description>

--- a/llama-dist/src/main/conf/llama-site.xml
+++ b/llama-dist/src/main/conf/llama-site.xml
@@ -425,7 +425,7 @@
     <description>
       Per queue setting that indicates if Llama should cache allocated resources
       on release for the #QUEUE# queue. If not set, the
-      'llama.am.caching.enabled' is used.
+      'llama.am.cache.enabled' is used.
     </description>
   </property>
   <property>

--- a/llama/src/main/java/com/cloudera/llama/am/api/LlamaAM.java
+++ b/llama/src/main/java/com/cloudera/llama/am/api/LlamaAM.java
@@ -95,7 +95,7 @@ public abstract class LlamaAM {
   public static final long GANG_ANTI_DEADLOCK_BACKOFF_MAX_DELAY_DEFAULT = 30000;
 
   public static final String CACHING_ENABLED_KEY =
-      PREFIX_KEY + "caching.enabled";
+      PREFIX_KEY + "cache.enabled";
   public static final boolean CACHING_ENABLED_DEFAULT = true;
 
   public static final String THROTTLING_ENABLED_KEY =

--- a/llama/src/main/java/com/cloudera/llama/am/impl/SingleQueueLlamaAM.java
+++ b/llama/src/main/java/com/cloudera/llama/am/impl/SingleQueueLlamaAM.java
@@ -122,6 +122,8 @@ public class SingleQueueLlamaAM extends LlamaAMImpl implements
           NORMALIZING_ENABLED_DEFAULT);
       caching = getConf().getBoolean(
           CACHING_ENABLED_KEY + "." + queue, caching);
+      normalizing = getConf().getBoolean(
+              NORMALIZING_ENABLED_KEY + "." + queue, normalizing);
       LOG.info("Caching for queue '{}' enabled '{}'", queue,
           caching);
       if (caching && normalizing) {


### PR DESCRIPTION
Issue description:

'DONT_CARE' locality enforcement option is ignored when client specifies it in the resource request. The problem is that after YARN allocates the resources they are matched by Llama against the request queue and the matching pattern includes node names.

Patch description:

Note: Addresses only the configuration with both resource caching and normalization disabled.
1. Introduce internal collection for ‘DONT_CARE’-attributed requests which were not granted yet.
2. After resources allocated by YARN have been ‘strongly’ matched against the existing requests, match the remaining of them against the new collection in a ‘weak’ fashion (only by number of vCPUs and amount of memory)
3. Matched resources are taken by Llama and removed from the new collection, while the rest of them are returned back into YARN pool.
4. Fix the inconsistency between the Llama source code and Llama config w.r.t. name (llama.am.caching.enabled vs llama.am.cache.enabled) of the property responsible for resource caching – currently the property change is ignored due to this
5. Add new config property (llama.am.resource.normalizing.enabled.#QUEUE#) to make disabling normalization for particular queue possible (rather than disabling normalization globally for all queues).

Signed-off-by: Mikhail Smorkalov mikhail.e.smorkalov@intel.com
